### PR TITLE
Add about and projects pages with spacing tweaks

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -23,3 +23,8 @@ socials:
     #icon: fa-graduation-cap
     #icon-style: solid
 
+
+menus:
+  main:
+    - title: About
+      url: /esiil_course/about/

--- a/about.md
+++ b/about.md
@@ -1,0 +1,7 @@
+---
+layout: page
+title: About
+permalink: /about/
+---
+This page provides information about me.
+

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -11,3 +11,13 @@ h2 { font-size: 22px; }
 h3 { font-size: 18px; }
 h4 { font-size: 16px; }
 
+
+#header .image.avatar {
+  margin-right: 0.75rem; /* adjust spacing */
+}
+
+a .icon,
+a svg,
+a .emoji {
+  margin-right: 0.25rem;
+}

--- a/projects.md
+++ b/projects.md
@@ -1,0 +1,7 @@
+---
+layout: page
+title: Projects
+permalink: /projects/
+---
+Details about my projects.
+


### PR DESCRIPTION
## Summary
- add avatar and link icon spacing tweaks in custom CSS
- create About and Projects pages with front matter
- configure About page in navigation menu

## Testing
- `jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_68ae29bded808322b906687b7bec95e9